### PR TITLE
Add color-coding to street blocks

### DIFF
--- a/app/src/main/java/com/github/genderquery/arcgis/rest/ArcGisRestClient.java
+++ b/app/src/main/java/com/github/genderquery/arcgis/rest/ArcGisRestClient.java
@@ -13,6 +13,8 @@ import retrofit2.converter.moshi.MoshiConverterFactory;
 public class ArcGisRestClient {
 
     private static final String TAG = "ArcGisRestClient";
+    private final OkHttpClient httpClient;
+    private final Moshi moshi;
     private Retrofit retrofit;
     private HashMap<Class, Object> services = new HashMap<>();
 
@@ -21,7 +23,8 @@ public class ArcGisRestClient {
     }
 
     public ArcGisRestClient(String url, OkHttpClient httpClient) {
-        Moshi moshi = new Moshi.Builder()
+        this.httpClient = httpClient;
+        moshi = new Moshi.Builder()
                 .add(SplitCollectionJsonAdapter.FACTORY)
                 .add(new ArcGisJsonAdapterFactory())
                 .build();
@@ -32,6 +35,18 @@ public class ArcGisRestClient {
                 .addConverterFactory(new ErrorResponseConverterFactory())
                 .addConverterFactory(MoshiConverterFactory.create(moshi))
                 .build();
+    }
+
+    public OkHttpClient getHttpClient() {
+        return httpClient;
+    }
+
+    public Moshi getMoshi() {
+        return moshi;
+    }
+
+    public Retrofit getRetrofit() {
+        return retrofit;
     }
 
     @SuppressWarnings("unchecked")

--- a/app/src/main/java/com/github/genderquery/arcgis/rest/service/MapService.java
+++ b/app/src/main/java/com/github/genderquery/arcgis/rest/service/MapService.java
@@ -32,7 +32,8 @@ public interface MapService {
     Call<QueryResponseBody> queryGeometry(
             @Path("layer") int layer,
             // TODO @Query("geometry") Geometry geometry
-            @Query("geometry") Envelope geometry
+            @Query("geometry") Envelope geometry,
             // TODO @Query("geometryType") GeometryType geometryType
+            @Query("outFields") String fields
     );
 }

--- a/app/src/main/java/com/github/genderquery/seattleparking/MainActivity.java
+++ b/app/src/main/java/com/github/genderquery/seattleparking/MainActivity.java
@@ -46,7 +46,7 @@ public class MainActivity extends AppCompatActivity implements
         mapFragment = (SupportMapFragment) getSupportFragmentManager()
                 .findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
-        mapService = SdotRestClient.getService(MapService.class);
+        mapService = SdotRestClient.getClient().getService(MapService.class);
         dpi = calculateScreenDpi();
     }
 
@@ -76,7 +76,7 @@ public class MainActivity extends AppCompatActivity implements
                 }
                 CoordinateProjector coordinateProjector = getCoordinateProjector();
                 final LayerTileProvider layerTileProvider =
-                        new LayerTileProvider(context, mapService, coordinateProjector, 7);
+                        new LayerTileProvider(context, coordinateProjector, 7);
                 final LatLngBounds fullExtent =
                         coordinateProjector.to(mapServiceInfo.fullExtent);
                 final LatLngBounds initialExtent =

--- a/app/src/main/java/com/github/genderquery/seattleparking/ParkingCategory.java
+++ b/app/src/main/java/com/github/genderquery/seattleparking/ParkingCategory.java
@@ -1,0 +1,12 @@
+package com.github.genderquery.seattleparking;
+
+import com.squareup.moshi.Json;
+
+public enum ParkingCategory {
+    @Json(name = "Carpool Parking")CARPOOL_PARKING,
+    @Json(name = "No Parking Allowed")NO_PARKING_ALLOWED,
+    @Json(name = "Paid Parking")PAID_PARKING,
+    @Json(name = "Restricted Parking Zone")RESTRICTED_PARKING_ZONE,
+    @Json(name = "Time Limited Parking")TIME_LIMITED_PARKING,
+    @Json(name = "Unrestricted Parking")UNRESTRICTED_PARKING,
+}

--- a/app/src/main/java/com/github/genderquery/seattleparking/SdotRestClient.java
+++ b/app/src/main/java/com/github/genderquery/seattleparking/SdotRestClient.java
@@ -1,12 +1,16 @@
 package com.github.genderquery.seattleparking;
 
+import android.graphics.Color;
+import android.graphics.DashPathEffect;
+
 import com.github.genderquery.arcgis.rest.ArcGisRestClient;
 import com.github.genderquery.arcgis.rest.model.SpatialReference;
 
-import okhttp3.OkHttpClient;
-import okhttp3.logging.HttpLoggingInterceptor;
+import java.util.EnumMap;
 
-public abstract class SdotRestClient {
+import okhttp3.OkHttpClient;
+
+public class SdotRestClient extends ArcGisRestClient {
 
     public static final SpatialReference WGS_1984_WEB_MERCATOR_AUXILIARY_SPHERE =
             new SpatialReference(3857);
@@ -18,24 +22,35 @@ public abstract class SdotRestClient {
 
     private static final String CATALOG_URL = "http://gisrevprxy.seattle.gov/" +
             "arcgis/rest/services/SDOT_EXT/SDOT_Parking/";
-    private static ArcGisRestClient client;
+    private static SdotRestClient client;
 
-    private SdotRestClient() {
-        // prevent instantiation
+    public EnumMap<ParkingCategory, Symbol> parkingCategorySymbols;
+
+    {
+        DashPathEffect dashPathEffect = new DashPathEffect(new float[]{10, 10}, 0);
+        parkingCategorySymbols = new EnumMap<>(ParkingCategory.class);
+        parkingCategorySymbols.put(ParkingCategory.CARPOOL_PARKING, new Symbol(Color.BLACK));
+        parkingCategorySymbols.put(ParkingCategory.NO_PARKING_ALLOWED, new Symbol(Color.RED));
+        parkingCategorySymbols.put(ParkingCategory.PAID_PARKING, new Symbol(Color.BLUE));
+        parkingCategorySymbols.put(ParkingCategory.RESTRICTED_PARKING_ZONE,
+                new Symbol(Color.RED, dashPathEffect));
+        parkingCategorySymbols.put(ParkingCategory.TIME_LIMITED_PARKING,
+                new Symbol(Color.GREEN, dashPathEffect));
+        parkingCategorySymbols.put(ParkingCategory.UNRESTRICTED_PARKING, new Symbol(Color.GREEN));
     }
 
-    public static <T> T getService(Class<T> serviceClass) {
-        return getClient().getService(serviceClass);
+    private SdotRestClient(String url, OkHttpClient httpClient) {
+        super(url, httpClient);
     }
 
-    public static ArcGisRestClient getClient() {
+    public static SdotRestClient getClient() {
         if (client == null) {
-            HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
-            logging.setLevel(HttpLoggingInterceptor.Level.BODY);
+//            HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
+//            logging.setLevel(HttpLoggingInterceptor.Level.BODY);
             OkHttpClient httpClient = new OkHttpClient.Builder()
-                    .addInterceptor(logging)
+//                    .addInterceptor(logging)
                     .build();
-            client = new ArcGisRestClient(CATALOG_URL, httpClient);
+            client = new SdotRestClient(CATALOG_URL, httpClient);
         }
         return client;
     }

--- a/app/src/main/java/com/github/genderquery/seattleparking/Symbol.java
+++ b/app/src/main/java/com/github/genderquery/seattleparking/Symbol.java
@@ -1,0 +1,18 @@
+package com.github.genderquery.seattleparking;
+
+import android.graphics.PathEffect;
+import android.support.annotation.ColorInt;
+
+public class Symbol {
+    @ColorInt public int color;
+    public PathEffect pathEffect;
+
+    public Symbol(@ColorInt int color) {
+        this.color = color;
+    }
+
+    public Symbol(@ColorInt int color, PathEffect pathEffect) {
+        this.color = color;
+        this.pathEffect = pathEffect;
+    }
+}


### PR DESCRIPTION
Street blocks are now styled depending on the value of
PARKING_CATEGORY in the entries attributes. Symbol holds a color and
a PathEffect so paths can be dashed, for example.

LayerTileProvider now has access to the Moshi instance through the
SdotRestClient singleton so it can parse PARKING_CATEGORY correctly.
This also takes the MapService out of the constructor.